### PR TITLE
# Fix : 스크롤 이슈 해결

### DIFF
--- a/src/page/MyPage/MyInfoPost.tsx
+++ b/src/page/MyPage/MyInfoPost.tsx
@@ -11,6 +11,7 @@ interface Post {
 
 export default function MyInfoPost() {
   const [postsData, setPostsData] = useState<Post[]>([]); // msw
+  //  const [hasMoreData, setHasMoreData] = useState(true); // 초기에는 더 많은 데이터가 있다고 가정
   const [containerClassName, setContainerClassName] = useState('flex-start');
   const [isLoading, setIsLoading] = useState(true); // 로딩 상태
   // const [defaultPost, setDefaultPost] = useState<Post[]>([]);
@@ -54,17 +55,16 @@ export default function MyInfoPost() {
           const startIndex = postsData.length;
 
           // 스크롤하면 3개씩 생성
-          const endIndex = startIndex + 3; // setPostsData3개씩 가지고오게함
+          const endIndex = startIndex + 3;
 
-          // const moreData = postsData.slice(startIndex, endIndex);
-          // msw를 통해 새로운 데이터를 가져옴
+          // msw를 통해 postsData에 데이터 추가
           fetch(`/api/posts?page=${endIndex / 3 + 1}`)
             .then(res => res.json())
             .then(data => {
               setIsLoading(true);
 
               // 새로운 데이터를 기존 데이터와 병합
-              setPostsData(prevData => [...prevData, ...data]);
+              setPostsData(prevData => [...prevData, ...data.slice(startIndex, endIndex)]);
               setIsLoading(false);
             })
             .catch(error => console.error('데이터 요청 실패:', error));

--- a/src/page/MyPage/MyInfoPost.tsx
+++ b/src/page/MyPage/MyInfoPost.tsx
@@ -13,7 +13,6 @@ export default function MyInfoPost() {
   const [postsData, setPostsData] = useState<Post[]>([]); // msw
   const [containerClassName, setContainerClassName] = useState('flex-start');
   const [isLoading, setIsLoading] = useState(true); // 로딩 상태
-  // const [defaultPost, setDefaultPost] = useState<Post[]>([]);
   const targetRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {

--- a/src/page/MyPage/MyInfoPost.tsx
+++ b/src/page/MyPage/MyInfoPost.tsx
@@ -11,7 +11,6 @@ interface Post {
 
 export default function MyInfoPost() {
   const [postsData, setPostsData] = useState<Post[]>([]); // msw
-  //  const [hasMoreData, setHasMoreData] = useState(true); // 초기에는 더 많은 데이터가 있다고 가정
   const [containerClassName, setContainerClassName] = useState('flex-start');
   const [isLoading, setIsLoading] = useState(true); // 로딩 상태
   // const [defaultPost, setDefaultPost] = useState<Post[]>([]);


### PR DESCRIPTION
```
  useEffect(() => {
    fetch('/api/posts')
      .then(res => res.json())
      .then(data => {
        setPostsData(data.slice(0, 6)); // 처음에 6개게시물만 나오게 설정
      })
      .catch(error => console.error('가짜 API 요청 실패:', error));
  }, []);
```
msw 핸들러 연결 -> 데이터는 6개만 먼저 들고오게함

```
function handleIntersection(entries: IntersectionObserverEntry[]) {
      entries.forEach(entry => {
        if (entry && entry.isIntersecting) {
          // 현재 게시물 길이
          const startIndex = postsData.length;

          // 스크롤하면 3개씩 생성
          const endIndex = startIndex + 3;

          // msw를 통해 postsData에 데이터 추가
          fetch(`/api/posts?page=${endIndex / 3 + 1}`)
            .then(res => res.json())
            .then(data => {
              setIsLoading(true);

              // 새로운 데이터를 기존 데이터와 병합
              setPostsData(prevData => [...prevData, ...data.slice(startIndex, endIndex)]);
              setIsLoading(false);
            })
            .catch(error => console.error('데이터 요청 실패:', error));
        }
      });
    }
```
여기서 fetch(`/api/posts?page=${endIndex / 3 + 1}`)부분이 msw에 데이터를 가지고 오는 부분이다 그리고 page가 게시글 고유 번호라고 생각하면 될꺼같다 
...data가 아닌 ...data.slice(startIndex, endIndex)이유는 ...data로 하면 계속 데이터를 가지고오고 반복을 하는데 slice를 사용해 게시물 id6까지 있는걸 id9까지 가지고 온다는 뜻이다고 게시물이 20개에서 끝나서 더이상 들고올게없어서 끝이난다.