### PR TITLE
# Docs : 전체일정 페이지 정렬기능 사용시 전체데이터가 뿌려지는이슈 수정완료

### DIFF
--- a/src/page/SchedulePage/Schedule.tsx
+++ b/src/page/SchedulePage/Schedule.tsx
@@ -71,7 +71,6 @@ function Schedule() {
       }
     }, 500);
   };
-
   const handleSortChange = (sortKey: string) => {
     let sortedData;
     switch (sortKey) {
@@ -87,7 +86,9 @@ function Schedule() {
       default:
         sortedData = data;
     }
-    setVisibleItems(sortedData);
+    setData(sortedData);
+    setVisibleItems(sortedData.slice(0, 9));
+    setAllItemsLoaded(false);
   };
 
   return (


### PR DESCRIPTION
최신순 에서 좋아요를 클릭했을때 무한스크롤이 먹히지 않고 전체 데이터가 싹다 보여지는이슈 수정완료