### PR TITLE
이슈 및 스웨거 체크

### DIFF
--- a/src/page/MyPage/EditInfo/EditForm.tsx
+++ b/src/page/MyPage/EditInfo/EditForm.tsx
@@ -106,16 +106,22 @@ export default function EditForm(props: EditFormProps) {
   };
 
   ///////////////////////현재비밀번호////////////////////
+  const [currentPasswordValue, setCurrentPasswordValue] = useState('');
+  const handleCurrentPasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newPasswordValue = e.target.value;
+    setCurrentPasswordValue(newPasswordValue);
+    console.log(newPasswordValue);
+  };
+
   const handleCurrentPasswordCheck = async () => {
     try {
       const response = await axios.post('/address/api/users/update/password/check', {
         email: userEmail,
-        password: passwordTest,
+        password: currentPasswordValue,
         // token: token,
       });
 
       if (response.status === 200) {
-        // dispatch(setToken(response.data.token));
         const message = response.data.passwordCheckOk;
         alert(`${message}`);
         setUserPassword('');
@@ -123,7 +129,7 @@ export default function EditForm(props: EditFormProps) {
         alert('유효하지 않은 사용자 입니다.');
       }
     } catch (error: any) {
-      console.log('password' + userPassword);
+      // console.log('password', currentPasswordValue);
       alert(`${error.response.data}`);
     }
   };
@@ -224,7 +230,7 @@ export default function EditForm(props: EditFormProps) {
             type="password"
             id="current-password"
             placeholder="현재비밀번호를 입력해주세요."
-            // onChange={handleCurrentPasswordChange}
+            onChange={handleCurrentPasswordChange}
             // value={userPassword}
           />
           <CheckBtn type="button" onClick={handleCurrentPasswordCheck}>

--- a/src/page/MyPage/EditInfo/EditMyInfo.tsx
+++ b/src/page/MyPage/EditInfo/EditMyInfo.tsx
@@ -59,7 +59,7 @@ export default function EditMyInfo() {
           newPassword: editedNewPassword,
           newNickname: editedNickname,
           newAboutMe: editedAboutMe,
-          newPasswordCheck: editedNewPassword,
+          // newPasswordCheck: editedNewPassword,
         },
         {
           headers: {


### PR DESCRIPTION
버튼 이슈는 토큰값이 지정이 되어져있어서 비번아닌걸 입력해도 체크완료되었다고 떴음 -> 토큰값을 지워서 다시하니까 입력값을 해싱해서 서버에 보내졌음 -> 입력값을 따로 저장을 해서 서버에 보내줌 -> 해결

원래 스웨거에 {
  "email": "string",
  "newAboutMe": "string",
  "newNickname": "string",
  "newPassword": "string" 
  "newPasswordCheck": "string"
}였는데
"newPasswordCheck": "string"이게 사라짐